### PR TITLE
Upgrade to 2.83.0

### DIFF
--- a/state.tf
+++ b/state.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.81.0"
+      version = "~> 2.83.0"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
### Change description ###
- Getting "Error: Resource instance managed by newer provider version" error on pipeline, upgrading to 2.83.0 fixes it.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
