### PR TITLE
Update Jenkins library to 2.2.0

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 //noinspection GroovyUnusedAssignment
-@Library("Infrastructure@DTSPO-30107-jenkins-agents") _
+@Library("Infrastructure@2.2.0") _
 
 def branchesToSync = ['demo', 'ithc']
 def product = "toffee"

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -1,7 +1,7 @@
 #!groovy
 import groovy.json.JsonSlurper
 
-@Library('Infrastructure@DTSPO-30107-jenkins-agents') _
+@Library('Infrastructure@2.2.0') _
 
 properties([
     parameters([

--- a/vault.tf
+++ b/vault.tf
@@ -1,7 +1,7 @@
 //KEY VAULT RESOURCE
 
 module "vault" {
-  source                     = "git@github.com:hmcts/cnp-module-key-vault?ref=1bbd75cb8d1d416831ebd91a04dc463471f5675a"
+  source                     = "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access"
   name                       = local.vault_name
   product                    = var.product
   env                        = var.env

--- a/vault.tf
+++ b/vault.tf
@@ -14,6 +14,7 @@ module "vault" {
   create_managed_identity    = true
   developers_group           = var.developers_group
   jenkins_object_id          = data.azurerm_user_assigned_identity.jenkins.principal_id
+  grant_dev_jenkins_access   = var.env == "stg"
 }
 
 output "vaultName" {

--- a/vault.tf
+++ b/vault.tf
@@ -1,7 +1,7 @@
 //KEY VAULT RESOURCE
 
 module "vault" {
-  source                     = "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access"
+  source                     = "git@github.com:hmcts/cnp-module-key-vault?ref=1bbd75cb8d1d416831ebd91a04dc463471f5675a"
   name                       = local.vault_name
   product                    = var.product
   env                        = var.env


### PR DESCRIPTION
Updates Jenkinsfiles to use `Infrastructure@2.2.0` so the pipeline can be validated against the fixed env-agent rollout tag.

No application code changes.
